### PR TITLE
Resolve issue #102 Infinite rendering

### DIFF
--- a/src/components/purpose/calender/CalenderSection.js
+++ b/src/components/purpose/calender/CalenderSection.js
@@ -13,6 +13,7 @@ import { changeWeekData, loadWeekDataMW } from "../../../redux/modules/weeks";
 const CalenderSection = () => {
   const dispatch = useDispatch();
 
+  const [weekHandler, setWeekHandler] = React.useState(0);
   const week = useSelector((state) => state.weeks.week);
   let [startDate, endDate] = useFindWeek(week);
 
@@ -24,7 +25,10 @@ const CalenderSection = () => {
     startDate: startDate.replace(".", ""),
     endDate: endDate.replace(".", ""),
   };
-  dispatch(loadWeekDataMW(myname, params));
+
+  React.useEffect(() => {
+    dispatch(loadWeekDataMW(myname, params));
+  }, [weekHandler]);
 
   const weekName = ["일", "월", "화", "수", "목", "금", "토"];
 
@@ -34,7 +38,10 @@ const CalenderSection = () => {
         <img
           src={arrowIcon}
           alt="left_arrow_icon"
-          onClick={() => dispatch(changeWeekData(week - 1))}
+          onClick={() => {
+            setWeekHandler(weekHandler - 1);
+            dispatch(changeWeekData(week-1));
+          }}
         />
         <h2>
           {startDate} ~ {endDate}
@@ -42,7 +49,10 @@ const CalenderSection = () => {
         <img
           src={arrowIcon}
           alt="right_arrow_icon"
-          onClick={() => dispatch(changeWeekData(week + 1))}
+          onClick={() => {
+            setWeekHandler(weekHandler + 1);
+            dispatch(changeWeekData(week+1));
+          }}
         />
       </WeekBox>
 

--- a/src/components/purpose/mydrug/SingleDrugLine.js
+++ b/src/components/purpose/mydrug/SingleDrugLine.js
@@ -9,11 +9,19 @@ import { devices } from "../../../device";
 import { drugApi } from "../../../api/drugApi";
 import { loadDrugDataMW } from "../../../redux/modules/drugs";
 import { RowFlexDiv } from "../../../style/styled";
-import { keepWeekDataMW } from "../../../redux/modules/weeks";
+import { keepWeekDataMW, loadWeekDataMW } from "../../../redux/modules/weeks";
+import { useSelector } from "react-redux";
+import { useFindWeek } from "../../../hooks/useFindWeek";
 
 const SingleDrugLine = ({ val, idx }) => {
   const username = useParams().username;
   const dispatch = useDispatch();
+  const week = useSelector((state) => state.weeks.week);
+  let [startDate, endDate] = useFindWeek(week);
+  const params = {
+    startDate: startDate.replace(".", ""),
+    endDate: endDate.replace(".", ""),
+  };
 
   const clickToCheckDrug = () => {
     var tmpDate = new Date();
@@ -26,6 +34,7 @@ const SingleDrugLine = ({ val, idx }) => {
     };
     drugApi.apiDrugCheck(data).then((res) => {
       dispatch(loadDrugDataMW(username));
+      dispatch(loadWeekDataMW(username, params));
     });
   };
 

--- a/src/redux/modules/weeks.js
+++ b/src/redux/modules/weeks.js
@@ -28,7 +28,7 @@ export function loadWeekDataMW(name, params) {
       .then((response) => {
         console.log(response.data,"너니?");
         // 무한 렌더링으로 인해 일단 주석처리
-        // dispatch(loadWeekData([...response.data]));
+        dispatch(loadWeekData([...response.data]));
       })
       .catch((error) => {
         console.log(error);


### PR DESCRIPTION
이슈가 깔끔히 잘 적혀있어서 금새 해결했습니다.
그 외에 스프라이트를 최적화를 넘어 애니메이터로 사용 된 모습도 인상깊습니다.
소현님 덕분에 전체적인 페이지 비율이 훨씬 이뻐졌습니다.

이슈 해결되었습니다.
근본적인 문제는 언제부턴가 useEffect에서 나와있던 dispatch 였구요.
dispatch에 의한 리듀서 작동, 스토어 변화에 의한 구독 랜더링.
이게 순환구조로 반복되고 있었습니다.

다음에 이같은 상황이 발생하면 weeks.js보다는 호출하는 코드를 더 보시면 도움이 될 것 같습니다.

weekhandler을 정의해서 가둬놨습니다.
useEffect가 state 디펜던시에만 반응하는게 setter 비동기와 합쳐지며 다루기 까다로워 지는 것 같습니다.
좋은 랜더링 구조는 아니지만 우선적으로 실현이 필요한 것 같아 적용했습니다.

그리고 체크해도 달력이 반응하지 않도록 바뀌었던데
이슈 해결 차원에서 잠시 삭제해두신 것 같기도 하고,,
의도하신건진 모르겠어서 복구해놨습니다.

시간도 얼마 남지 않은만큼 소현님 이슈등록 해주시면 그때그때 함께 고민할 수 있도록 하겠습니다.

