### PR TITLE
캘린더 이슈 해결했습니다.

### DIFF
--- a/src/components/layout/button/ShopBtn.tsx
+++ b/src/components/layout/button/ShopBtn.tsx
@@ -22,7 +22,7 @@ const ShopBtn = () => {
   const autoRemover = () => {
       setTimeout(() => {
         dispatch(switchShopNoticeModal(false));
-      }, 1500);
+      }, 1400);
   };
 
   return (

--- a/src/components/purpose/calender/DateViewCard.tsx
+++ b/src/components/purpose/calender/DateViewCard.tsx
@@ -16,7 +16,7 @@ const DateViewCard = ({ day, myWeek, array }: GreetingsProps) => {
       <h3>{day}</h3>
       {myWeek &&
         myWeek
-          .filter((value, index) => value.dayOfWeekValue == array.indexOf(day))
+          .filter((value, index) => new Date(value.usedAt).getDay() == array.indexOf(day))
           .map((val, index) => {
             return (
               <div


### PR DESCRIPTION
해결)
 usedAt을 기반으로 동일한 datetime 데이터를 만들어서 내부 함수 이용해 요일을 뽑아왔습니다.
단순 JS와 JAVA 차이이므로 그나마 해결하기 쉬운 이 방법 사용하겠습니다.
dayOfWeekValue는 더이상 사용하지 않게 되었습니다.

**DateViewCard.tsx : Line19**
- **기존**
`value.dayOfWeekValue == array.indexOf(day)`

- **변경 후**
`new Date(value.usedAt).getDay() == array.indexOf(day)`

문제)
> ![image](https://user-images.githubusercontent.com/85068289/189514212-312dcbe5-d4a6-4cd4-a4db-02d2ed18d975.png)

